### PR TITLE
Fix import of module Pillow.Image

### DIFF
--- a/cooperhewitt/roboteyes/atkinson/__init__.py
+++ b/cooperhewitt/roboteyes/atkinson/__init__.py
@@ -1,4 +1,4 @@
-import Image
+from PIL import Image
 import logging
 
 def dither(src_path, dest_path, mime_type='GIF'):


### PR DESCRIPTION
Hello, I got the following exception in [line 16](https://github.com/nok/py-cooperhewitt-roboteyes-atkinson/blob/master/cooperhewitt/roboteyes/atkinson/__init__.py#L16): 

```
cannot identify image file '0000.png'
```

The error is in [line 26](https://github.com/nok/py-cooperhewitt-roboteyes-atkinson/blob/master/cooperhewitt/roboteyes/atkinson/__init__.py#L26). We just need to import the class `Image` from the module `PIL` explicitly.
